### PR TITLE
Add before filter to keep new files

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,6 @@ $ slack-filesave -token=xxxxxx-xxxxxxxxx -type=image
 | :--- | :---------- | :-----: | :-----: |
 | token | your slack api token |  | true |
 | type | filter file type | all |  |
+| before | filter file by timestamp (older than) | now |  |
 | private | include private files | false |  |
 | delete | delete downloaded file from slack | false |  |


### PR DESCRIPTION
Hi!

I wanted to delete the only old files on Slack and keep the newer ones. So I added `before` flag to filter the target files.

We can use it like this.

```sh
# Download files older than 1 year
slack-filesave -token=MY_TOKEN -before=`date -v-1y +%s`

# Delete files older than 1 day
slack-filesave -token=MY_TOKEN -delete -before=`date -v-1d +%s`
```

Could you please review this and merge if you like it?